### PR TITLE
Update root.prisma

### DIFF
--- a/apps/quarkloop/prisma/root.prisma
+++ b/apps/quarkloop/prisma/root.prisma
@@ -5,6 +5,5 @@ generator client {
 datasource db {
     provider          = "postgresql"
     url               = env("POSTGRES_PRISMA_URL") // uses connection pooling
-    directUrl         = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
-    shadowDatabaseUrl = env("POSTGRES_URL_NON_POOLING") // used for migrations    
+    directUrl         = env("POSTGRES_URL_NON_POOLING") // used for migrations
 }


### PR DESCRIPTION
`shadowDatabaseUrl` is no longer required for Vercel Postgres and may cause issues when set to the same value as `directUrl`.